### PR TITLE
CFP-1752 Make test results folder configurable

### DIFF
--- a/domains/v1/domains_suite_test.go
+++ b/domains/v1/domains_suite_test.go
@@ -4,15 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
-	"os"
-	"testing"
-	"time"
-
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	"log"
+	"testing"
 
 	"github.com/cloudfoundry-incubator/cf-performance-tests/helpers"
 )
@@ -74,27 +70,6 @@ var _ = AfterSuite(func() {
 })
 
 func TestDomains(t *testing.T) {
-	viper.SetConfigName("config")
-	viper.AddConfigPath("../../")
-	viper.AddConfigPath("$HOME/.cf-performance-tests")
-	err := viper.ReadInConfig()
-	if err != nil {
-		t.Fatalf("error loading config: %s", err.Error())
-	}
-
-	err = viper.Unmarshal(&testConfig)
-	if err != nil {
-		t.Fatalf("error parsing config: %s", err.Error())
-	}
-
-	err = os.MkdirAll("../../test-results/domains-test-results/v1/", os.ModePerm)
-	if err != nil {
-		t.Fatalf("Cannot create Directory: %s", err.Error())
-	}
-
-	timestamp := time.Now().Unix()
-	jsonReporter := helpers.NewJsonReporter(fmt.Sprintf("../../test-results/domains-test-results/v1/domains-test-results-%d.json", timestamp), testConfig.CfDeploymentVersion, testConfig.CapiVersion, timestamp)
-
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "DomainsTest Suite", []Reporter{jsonReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "DomainsTest Suite", []Reporter{helpers.ConfigureJsonReporter(t, &testConfig, "domains")})
 }

--- a/isolation_segments/v1/isolation_segments_suite_test.go
+++ b/isolation_segments/v1/isolation_segments_suite_test.go
@@ -4,17 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
-	"os"
-	"testing"
-	"time"
-
+	"github.com/cloudfoundry-incubator/cf-performance-tests/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
-
-	"github.com/cloudfoundry-incubator/cf-performance-tests/helpers"
+	"log"
+	"testing"
 )
 
 var testConfig = helpers.NewConfig()
@@ -75,27 +70,6 @@ var _ = AfterSuite(func() {
 })
 
 func TestIsolationSegments(t *testing.T) {
-	viper.SetConfigName("config")
-	viper.AddConfigPath("../../")
-	viper.AddConfigPath("$HOME/.cf-performance-tests")
-	err := viper.ReadInConfig()
-	if err != nil {
-		t.Fatalf("error loading config: %s", err.Error())
-	}
-
-	err = viper.Unmarshal(&testConfig)
-	if err != nil {
-		t.Fatalf("error parsing config: %s", err.Error())
-	}
-
-	err = os.MkdirAll("../../test-results/isolation-segments-test-results/v1/", os.ModePerm)
-	if err != nil {
-		t.Fatalf("Cannot create Directory: %s", err.Error())
-	}
-
-	timestamp := time.Now().Unix()
-	jsonReporter := helpers.NewJsonReporter(fmt.Sprintf("../../test-results/isolation-segments-test-results/v1/isolation-segments-test-results-%d.json", timestamp), testConfig.CfDeploymentVersion, testConfig.CapiVersion, timestamp)
-
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "IsolationSegmentsTest Suite", []Reporter{jsonReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "IsolationSegmentsTest Suite", []Reporter{helpers.ConfigureJsonReporter(t, &testConfig, "isolation-segments")})
 }

--- a/security_groups/v1/security_groups_suite_test.go
+++ b/security_groups/v1/security_groups_suite_test.go
@@ -4,17 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
-	"os"
-	"testing"
-	"time"
-
+	"github.com/cloudfoundry-incubator/cf-performance-tests/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
-
-	"github.com/cloudfoundry-incubator/cf-performance-tests/helpers"
+	"log"
+	"testing"
 )
 
 var testConfig = helpers.NewConfig()
@@ -81,27 +76,6 @@ var _ = AfterSuite(func() {
 })
 
 func TestSecurityGroups(t *testing.T) {
-	viper.SetConfigName("config")
-	viper.AddConfigPath("../../")
-	viper.AddConfigPath("$HOME/.cf-performance-tests")
-	err := viper.ReadInConfig()
-	if err != nil {
-		t.Fatalf("error loading config: %s", err.Error())
-	}
-
-	err = viper.Unmarshal(&testConfig)
-	if err != nil {
-		t.Fatalf("error parsing config: %s", err.Error())
-	}
-
-	err = os.MkdirAll("../../test-results/security-groups-test-results/v1/", os.ModePerm)
-	if err != nil {
-		t.Fatalf("Cannot create Directory: %s", err.Error())
-	}
-
-	timestamp := time.Now().Unix()
-	jsonReporter := helpers.NewJsonReporter(fmt.Sprintf("../../test-results/security-groups-test-results/v1/security-groups-test-results-%d.json", timestamp), testConfig.CfDeploymentVersion, testConfig.CapiVersion, timestamp)
-
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "SecurityGroupsTest Suite", []Reporter{jsonReporter})
+	RunSpecsWithDefaultAndCustomReporters(t, "SecurityGroupsTest Suite", []Reporter{helpers.ConfigureJsonReporter(t, &testConfig, "security-groups")})
 }


### PR DESCRIPTION
* should make it easier to separate regular CF tests / go-cc tests
* extract common viper config coding