### PR TITLE
CFP-2025 psql and mysql procedures need same name

### DIFF
--- a/audit_events/v1/audit_events_suite_test.go
+++ b/audit_events/v1/audit_events_suite_test.go
@@ -46,7 +46,7 @@ var _ = BeforeSuite(func() {
 	helpers.ExecuteStoredProcedure(ccdb, ctx, createSpacesStatement, testConfig)
 
 	// create events helper table
-	createEventsTableStatement := fmt.Sprintf("create_table_event_types()")
+	createEventsTableStatement := fmt.Sprintf("create_event_types_table()")
 	helpers.ExecuteStoredProcedure(ccdb, ctx, createEventsTableStatement, testConfig)
 
 	// create events

--- a/helpers/database.go
+++ b/helpers/database.go
@@ -174,6 +174,7 @@ func CleanupTestData(ccdb, uaadb *sql.DB, ctx context.Context, testConfig Config
 			ExecuteStatement(ccdb, ctx, fmt.Sprintf(statement, nameQuery))
 		}
 		ExecuteStatement(ccdb, ctx, fmt.Sprintf("DROP TABLE IF EXISTS event_types"))
+		ExecuteStatement(ccdb, ctx, fmt.Sprintf("TRUNCATE events"))
 		log.Printf("%v Running 'VACUUM FULL' on db...\n", time.Now().Format(time.RFC850))
 		ExecuteStatement(ccdb, ctx, "VACUUM FULL;")
 	}
@@ -183,6 +184,7 @@ func CleanupTestData(ccdb, uaadb *sql.DB, ctx context.Context, testConfig Config
 			ExecuteStatement(ccdb, ctx, fmt.Sprintf(statement, nameQuery))
 		}
 		ExecuteStatement(ccdb, ctx, fmt.Sprintf("DROP TABLE IF EXISTS event_types"))
+		ExecuteStatement(ccdb, ctx, fmt.Sprintf("TRUNCATE events"))
 	}
 
 	if uaadb != nil {

--- a/scripts/mysql/create_event_types_table.tmpl.sql
+++ b/scripts/mysql/create_event_types_table.tmpl.sql
@@ -1,12 +1,13 @@
 CREATE PROCEDURE create_event_types_table()
 BEGIN
+    DROP TABLE IF EXISTS event_types;
     create table event_types
         (
-            Id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            type VARCHAR(128),
+            id INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+            audit_event_type VARCHAR(128),
             count_events INT
         );
-    INSERT INTO event_types (type, count_events) VALUES ('audit.user.space_developer_add',100000),
+    INSERT INTO event_types (audit_event_type, count_events) VALUES ('audit.user.space_developer_add',100000),
                                                         ('audit.app.environment_variables.show',100000),
                                                         ('audit.service_binding.delete',100000),
                                                         ('audit.user.organization_manager_remove',50000),
@@ -72,7 +73,7 @@ BEGIN
                                                         ('audit.service_instance.start_update',1000),
                                                         ('audit.app.deployment.create',1000),
                                                         ('audit.space.create',1000),
-                                                        ('audit.space.delete-request',1000),
+                                                        ('audit.space.delete-request',500),
                                                         ('audit.organization.update',500),
                                                         ('audit.user_provided_service_instance.create',500),
                                                         ('audit.user_provided_service_instance.delete',500),

--- a/scripts/mysql/create_events.tmpl.sql
+++ b/scripts/mysql/create_events.tmpl.sql
@@ -8,7 +8,7 @@ BEGIN
     DECLARE space_guid VARCHAR(255);
     DECLARE events_guid VARCHAR(255);
     DECLARE finished BOOLEAN DEFAULT FALSE;
-    DECLARE events_cursor CURSOR FOR SELECT "type", count_events FROM event_types;
+    DECLARE events_cursor CURSOR FOR SELECT audit_event_type, count_events FROM event_types;
     DECLARE import_cursor CURSOR FOR SELECT ean, sku, mpn, manufacturerName, manufacturerUniqueId, images FROM importjob;
     DECLARE CONTINUE HANDLER FOR NOT FOUND SET finished = TRUE;
 

--- a/scripts/pgsql_functions.tmpl.sql
+++ b/scripts/pgsql_functions.tmpl.sql
@@ -315,13 +315,14 @@ $$ LANGUAGE plpgsql;
 -- ============================================================= --
 
 -- FUNC DEF:
-CREATE OR REPLACE FUNCTION create_table_event_types(
+CREATE OR REPLACE FUNCTION create_event_types_table(
 ) RETURNS void AS
 $$
 
 BEGIN
-    CREATE table event_types (id serial primary key , "type" VARCHAR(128), count_events INT);
-    INSERT INTO event_types ("type", count_events) VALUES ('audit.user.space_developer_add',100000),
+    DROP TABLE IF EXISTS event_types;
+    CREATE table event_types (id serial primary key , audit_event_type VARCHAR(128), count_events INT);
+    INSERT INTO event_types (audit_event_type, count_events) VALUES ('audit.user.space_developer_add',100000),
                                                           ('audit.app.environment_variables.show',100000),
                                                           ('audit.service_binding.delete',100000),
                                                           ('audit.user.organization_manager_remove',50000),
@@ -448,7 +449,7 @@ DECLARE
     events_actee_prefix text := '{{.Prefix}}-events-actee-';
     events_actee_type_prefix text := '{{.Prefix}}-events-actee-type-';
 BEGIN
-    FOR event_type, num_events IN (SELECT "type", count_events FROM event_types) LOOP
+    FOR event_type, num_events IN (SELECT audit_event_type, count_events FROM event_types) LOOP
         FOR amount IN 1..num_events LOOP
             events_guid := gen_random_uuid();
             SELECT guid FROM organizations WHERE name LIKE org_name_query ORDER BY random() LIMIT 1 INTO org_guid;


### PR DESCRIPTION
Change psql procedure name to mysql procedure name so that it can be called in the audit events test suite no matter which db 