### PR TITLE
Add destinations performance tests

### DIFF
--- a/destinations/v1/destinations_suite_test.go
+++ b/destinations/v1/destinations_suite_test.go
@@ -1,0 +1,127 @@
+package destinations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"testing"
+	"os"
+
+	"github.com/google/uuid"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+)
+
+var testConfig = helpers.NewConfig()
+var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
+var ccdb *sql.DB
+var uaadb *sql.DB
+var ctx context.Context
+var appGuid1 string
+var appGuid2 string
+var appName1 string
+var appName2 string
+var spaceGuid string
+
+// diego seems to have a limitation here
+// when binding more routes to an app the app does not start, or it will fail during staging already
+const (
+	routeMappings = 800
+)
+
+func setupAppAndSeedDB(appName string, spaceGuid string) string {
+	data := fmt.Sprintf(`{
+                           "name": "%s",
+                           "relationships": {
+                             "space": {
+                               "data": {
+                                 "guid": "%s"
+                               }
+                             }
+                           }
+                         }`, appName, spaceGuid)
+
+	exitCode, appCreateBody := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "POST", "/v3/apps", "-d", data)
+
+	Expect(exitCode).To(Equal(0))
+	Expect(appCreateBody).To(ContainSubstring("201 Created"))
+
+	appCreateResponse := helpers.ParseCreateResponseBody(helpers.RemoveDebugOutput(appCreateBody))
+	appGuid := appCreateResponse.GUID
+
+	helpers.ImportStoredProcedures(ccdb, ctx, testConfig)
+
+	createRouteMappingsStatement := fmt.Sprintf("create_routes_and_route_mappings_for_app('%s', '%s', '%s', %d)", appGuid, testSetup.GetOrganizationName(), spaceGuid, routeMappings)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createRouteMappingsStatement, testConfig)
+
+	log.Printf("Preparing app directory and files.")
+	appDir := helpers.CreateAppFolder(appName1)
+	defer os.RemoveAll(appDir)
+
+	log.Printf("Pushing app `%s`", appName)
+	pushResult := cf.Push(appName, "-i", "1", "-b", "staticfile_buildpack", "-p", appDir).Wait(120)
+	if pushResult.ExitCode() != 0 {
+		panic("Push not successful")
+	}
+
+	return appGuid
+}
+
+var _ = BeforeSuite(func() {
+	testSetup = workflowhelpers.NewTestSuiteSetup(&testConfig)
+	testSetup.Setup()
+	ccdb, uaadb, ctx = helpers.OpenDbConnections(testConfig)
+
+	spaceName := testSetup.TestSpace.SpaceName()
+	spaceGuids := helpers.GetGUIDs(testSetup.AdminUserContext(), testConfig, fmt.Sprintf("/v3/spaces?names=%s", spaceName))
+	spaceGuid = spaceGuids[0]
+
+	appName1 = fmt.Sprintf("%s-app-%s", testConfig.GetNamePrefix(), uuid.NewString())
+	appName2 = fmt.Sprintf("%s-app-%s", testConfig.GetNamePrefix(), uuid.NewString())
+
+	appGuid1 = setupAppAndSeedDB(appName1, spaceGuid)
+	appGuid2 = setupAppAndSeedDB(appName2, spaceGuid)
+
+	helpers.AnalyzeDB(ccdb, ctx, testConfig)
+	log.Printf("Finished seeding database.")
+})
+
+var _ = AfterSuite(func() {
+	log.Printf("Deleting app `%s`\n", appName1)
+	helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "DELETE", fmt.Sprintf("/v3/apps/%s", appGuid1))
+
+	log.Printf("Deleting app `%s`\n", appName2)
+	helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "DELETE", fmt.Sprintf("/v3/apps/%s", appGuid2))
+
+	log.Printf("Starting cleanup testdata...")
+	helpers.CleanupTestData(ccdb, uaadb, ctx, testConfig)
+	log.Printf("Finished cleanup testdata.")
+	err := ccdb.Close()
+	if err != nil {
+		log.Print(err)
+	}
+
+	if uaadb != nil {
+		err = uaadb.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}
+})
+
+var _ = ReportAfterSuite("Destinations test suite", func(report types.Report) {
+	helpers.GenerateReports(helpers.ConfigureJsonReporter(&testConfig, "destinations", "destinations"), report)
+})
+
+func TestDestinations(t *testing.T) {
+	helpers.LoadConfig(&testConfig)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Destinations Test Suite")
+}

--- a/destinations/v1/destinations_test.go
+++ b/destinations/v1/destinations_test.go
@@ -1,0 +1,151 @@
+package destinations
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gmeasure"
+	"github.com/google/uuid"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+)
+
+var _ = Describe("destinations", func() {
+	Describe("as admin", func() {
+		var routeGUIDs []string
+
+		BeforeEach(func() {
+			routeGUIDs = nil
+			domainGUID := helpers.ApiCall(testSetup.AdminUserContext(), testConfig, "/v3/domains").Resources[0].GUID
+
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+				// create one route per sample
+				for range make([]struct{}, testConfig.Samples) {
+					host := fmt.Sprintf("%s-host-%s", testConfig.GetNamePrefix(), uuid.NewString())
+					data := fmt.Sprintf(`{
+                                           "host": "%s",
+                                           "relationships": {
+                                             "domain": {
+                                               "data": {
+                                                 "guid": "%s"
+                                               }
+                                             },
+                                             "space": {
+                                               "data": {
+                                                 "guid": "%s"
+                                               }
+                                             }
+                                           }
+                                         }`, host, domainGUID, spaceGuid)
+
+					exitCode, body := helpers.TimeCFCurlReturning(testConfig.BasicTimeout, "-X", "POST", "-d", data, "/v3/routes")
+
+					Expect(exitCode).To(Equal(0))
+					Expect(body).To(ContainSubstring("201 Created"))
+
+					response := helpers.ParseCreateResponseBody(helpers.RemoveDebugOutput(body))
+					routeGUIDs = append(routeGUIDs, response.GUID)
+				}
+			})
+		})
+
+		Context("using a single app", func() {
+			It("creates a new destination", func() {
+				experiment := gmeasure.NewExperiment("POST /v3/routes/:guid/destinations::as admin::using single app")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("POST /v3/routes/:guid/destinations", func() {
+							data := fmt.Sprintf(`{"destinations": [ { "app": { "guid": "%s"} } ] }`, appGuid1)
+							exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "POST", "-d", data, fmt.Sprintf("/v3/routes/%s/destinations", routeGUIDs[idx]))
+
+							Expect(exitCode).To(Equal(0))
+							Expect(body).To(ContainSubstring("200 OK"))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("replaces destinations of a route", func() {
+				experiment := gmeasure.NewExperiment("PATCH /v3/routes/:guid/destinations::as admin::using single app")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("PATCH /v3/routes/:guid/destinations", func() {
+							data := fmt.Sprintf(`{"destinations": [ { "app": { "guid": "%s"} } ] }`, appGuid1)
+							exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "PATCH", "-d", data, fmt.Sprintf("/v3/routes/%s/destinations", routeGUIDs[idx]))
+
+							Expect(exitCode).To(Equal(0))
+							Expect(body).To(ContainSubstring("200 OK"))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("removes a destination from a route", func() {
+				experiment := gmeasure.NewExperiment("DELETE /v3/routes/:guid/destinations/:guid::as admin::using single app")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+					experiment.Sample(func(idx int) {
+						data := fmt.Sprintf(`{"destinations": [ { "app": { "guid": "%s"} } ] }`, appGuid1)
+						exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "POST", "-d", data, fmt.Sprintf("/v3/routes/%s/destinations", routeGUIDs[idx]))
+
+						Expect(exitCode).To(Equal(0))
+						Expect(body).To(ContainSubstring("200 OK"))
+
+						response := helpers.ParseDestinationsCreateResponseBody(helpers.RemoveDebugOutput(body))
+						destinationGuid := response.Destinations[0].GUID
+
+						experiment.MeasureDuration("DELETE /v3/routes/:guid/destinations/:guid", func() {
+							exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "DELETE", fmt.Sprintf("/v3/routes/%s/destinations/%s", routeGUIDs[idx], destinationGuid))
+
+							Expect(exitCode).To(Equal(0))
+							Expect(body).To(ContainSubstring("204 No Content"))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+
+		Context("using two apps", func() {
+			It("creates new destinations", func() {
+				experiment := gmeasure.NewExperiment("POST /v3/routes/:guid/destinations::as admin::using two apps")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("POST /v3/routes/:guid/destinations", func() {
+							data := fmt.Sprintf(`{"destinations": [ { "app": { "guid": "%s"} }, { "app": { "guid": "%s"} } ] }`, appGuid1, appGuid2)
+							exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "POST", "-d", data, fmt.Sprintf("/v3/routes/%s/destinations", routeGUIDs[idx]))
+
+							Expect(exitCode).To(Equal(0))
+							Expect(body).To(ContainSubstring("200 OK"))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("replaces destinations of a route", func() {
+				experiment := gmeasure.NewExperiment("PATCH /v3/routes/:guid/destinations::as admin::using two apps")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("PATCH /v3/routes/:guid/destinations", func() {
+							data := fmt.Sprintf(`{"destinations": [ { "app": { "guid": "%s"} }, { "app": { "guid": "%s"} } ] }`, appGuid1, appGuid2)
+							exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "-X", "PATCH", "-d", data, fmt.Sprintf("/v3/routes/%s/destinations", routeGUIDs[idx]))
+
+							Expect(exitCode).To(Equal(0))
+							Expect(body).To(ContainSubstring("200 OK"))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+	})
+})

--- a/helpers/api.go
+++ b/helpers/api.go
@@ -1,12 +1,14 @@
 package helpers
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"log"
 
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
@@ -25,22 +27,64 @@ type APIResponse struct {
 	} `json:"resources"`
 }
 
+type APICreateResponse struct {
+    GUID string `json:"guid"`
+}
+
+type DestinationsCreateResponse struct {
+    Destinations []struct {
+        GUID    string `json:"guid"`
+    } `json:"destinations"`
+}
+
+func ParseDestinationsCreateResponseBody(body []byte) *DestinationsCreateResponse {
+    var resp *DestinationsCreateResponse
+    err := json.Unmarshal(body, &resp)
+
+    if err != nil {
+
+        return nil
+    }
+    return resp
+}
+
+func ParseCreateResponseBody(body []byte) *APICreateResponse {
+    var resp *APICreateResponse
+    err := json.Unmarshal(body, &resp)
+
+    if err != nil {
+
+        return nil
+    }
+    return resp
+}
+
 func RemoveDebugOutput(body []byte) []byte {
-	scanner := bufio.NewScanner(bytes.NewReader(body))
-	var buffer bytes.Buffer
-	write := false
+    var jsons [][]byte
+    start := -1
+    level := 0
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "{") {
-			write = true
-		}
-		if write {
-			buffer.WriteString(line + "\n")
-		}
-	}
+    for i, r := range body {
+        if r == '{' {
+            if start == -1 {
+                start = i
+            }
+            level++
+        } else if r == '}' {
+            level--
+            if level == 0 {
+                jsons = append(jsons, body[start:i+1])
+                start = -1
+            }
+        }
+    }
 
-	return buffer.Bytes()
+    // For POST there will be 2 jsons in the output. Return the second one, which is the response.
+    if len(jsons) > 1 {
+        return jsons[1]
+    } else { // For GET there is just one json
+        return jsons[0]
+    }
 }
 
 func ParseResponseBody(body []byte) *APIResponse {
@@ -52,7 +96,7 @@ func ParseResponseBody(body []byte) *APIResponse {
 	return resp
 }
 
-func apiCall(user workflowhelpers.UserContext, testConfig Config, endpoint string) *APIResponse {
+func ApiCall(user workflowhelpers.UserContext, testConfig Config, endpoint string) *APIResponse {
 	var session *Session
 	workflowhelpers.AsUser(user, testConfig.BasicTimeout, func() {
 		session = cf.Cf("curl", "--fail", endpoint).Wait(testConfig.BasicTimeout)
@@ -63,7 +107,7 @@ func apiCall(user workflowhelpers.UserContext, testConfig Config, endpoint strin
 
 func GetGUIDs(user workflowhelpers.UserContext, testConfig Config, endpoint string) []string {
 	var guids []string
-	resp := apiCall(user, testConfig, endpoint)
+	resp := ApiCall(user, testConfig, endpoint)
 	if resp != nil {
 		for _, item := range resp.Resources {
 			// do not select non-test resources (e.g. the default CF orgs or security groups)
@@ -107,4 +151,37 @@ func TimeCFCurlReturning(timeout time.Duration, curlArguments ...string) (int, [
 	result := cf.Cf(args...).Wait(timeout)
 
 	return result.ExitCode(), result.Out.Contents()
+}
+
+func CreateAppFolder(appName string) string {
+    // Create a temporary directory
+    tempDir, err := ioutil.TempDir("", "app")
+    if err != nil {
+        panic(err)
+    }
+
+    log.Printf("Created a temporary directory: %s", tempDir)
+
+    // Create a new file in the temporary directory
+    indexFile, err := os.Create(fmt.Sprintf("%s/%s",tempDir, "index.html"))
+    if err != nil {
+        panic(err)
+    }
+
+    log.Printf("Created a temporary file: %s", indexFile.Name())
+
+    msg := []byte("Hello, World!")
+    if _, err := indexFile.Write(msg); err != nil {
+        panic(err)
+    }
+
+    // You need to close the file after writing
+    if err := indexFile.Close(); err != nil {
+        panic(err)
+    }
+
+    // Get the directory of the temporary file
+    dir := filepath.Dir(indexFile.Name())
+
+    return dir
 }

--- a/helpers/database.go
+++ b/helpers/database.go
@@ -107,11 +107,15 @@ func GetRandomFunction(testConfig Config) string {
 func CleanupTestData(ccdb, uaadb *sql.DB, ctx context.Context, testConfig Config) {
 	deleteStatementsPostgres := []string{
 		"DELETE FROM route_mappings USING routes WHERE routes.guid = route_mappings.route_guid AND routes.host LIKE '%s'",
+		"DELETE FROM service_bindings USING apps WHERE apps.guid = service_bindings.app_guid AND apps.name LIKE '%s'",
 		"DELETE FROM routes WHERE host LIKE '%s'",
 		"DELETE FROM domain_annotations USING domains WHERE domain_annotations.resource_guid = domains.guid AND domains.name LIKE '%s'",
 		"DELETE FROM domains WHERE name LIKE '%s'",
-		"DELETE FROM service_bindings USING apps WHERE apps.guid = service_bindings.app_guid AND apps.name LIKE '%s'",
-		"DELETE FROM route_mappings USING apps WHERE apps.guid = route_mappings.app_guid AND apps.name LIKE '%s'",
+		"DELETE FROM processes USING apps WHERE apps.guid = processes.app_guid AND apps.name LIKE '%s'",
+		"DELETE FROM packages USING apps WHERE apps.guid = packages.app_guid AND apps.name LIKE '%s'",
+		"DELETE FROM builds USING apps WHERE apps.guid = builds.app_guid AND apps.name LIKE '%s'",
+		"DELETE FROM droplets USING apps WHERE apps.guid = droplets.app_guid AND apps.name LIKE '%s'",
+		"DELETE FROM revisions USING apps WHERE apps.guid = revisions.app_guid AND apps.name LIKE '%s'",
 		"DELETE FROM apps WHERE name LIKE '%s'",
 		"DELETE FROM service_keys WHERE name LIKE '%s'",
 		"DELETE FROM service_bindings USING service_instances WHERE service_instances.guid = service_bindings.service_instance_guid AND service_instances.name LIKE '%s'",
@@ -144,8 +148,16 @@ func CleanupTestData(ccdb, uaadb *sql.DB, ctx context.Context, testConfig Config
 		"DELETE FROM service_brokers WHERE name LIKE '%s'",
 	}
 	deleteStatementsMySql := []string{
+		"DELETE FROM r_m USING route_mappings r_m, routes r WHERE r.guid = r_m.route_guid AND r.host LIKE '%s'",
+		"DELETE FROM r USING routes r, spaces s WHERE s.id = r.space_id AND s.name LIKE '%s'",
 		"DELETE FROM d_a USING domain_annotations d_a, domains d WHERE d_a.resource_guid = d.guid AND d.name LIKE '%s'",
 		"DELETE FROM domains WHERE name LIKE '%s'",
+		"DELETE FROM p USING processes p, apps a WHERE a.guid = p.app_guid AND a.name LIKE '%s'",
+		"DELETE FROM p USING packages p, apps a WHERE a.guid = p.app_guid AND a.name LIKE '%s'",
+		"DELETE FROM b USING builds b, apps a WHERE a.guid = b.app_guid AND a.name LIKE '%s'",
+		"DELETE FROM d USING droplets d, apps a WHERE a.guid = d.app_guid AND a.name LIKE '%s'",
+		"DELETE FROM r USING revisions r, apps a WHERE a.guid = r.app_guid AND a.name LIKE '%s'",
+		"DELETE FROM apps WHERE name LIKE '%s'",
 		"DELETE FROM service_keys WHERE name LIKE '%s'",
 		"DELETE FROM s_b USING service_bindings s_b, service_instances s_i WHERE s_i.guid = s_b.service_instance_guid AND s_i.name LIKE '%s'",
 		"DELETE FROM service_instances WHERE name LIKE '%s'",
@@ -174,7 +186,6 @@ func CleanupTestData(ccdb, uaadb *sql.DB, ctx context.Context, testConfig Config
 		"DELETE FROM service_brokers WHERE name LIKE '%s'",
 		"DELETE FROM events WHERE actee_name LIKE '%s'",
 		"DELETE FROM events WHERE actee LIKE '%s'",
-		"DELETE FROM apps WHERE name LIKE '%s'",
 		"DELETE FROM quota_definitions WHERE name LIKE '%s'",
 	}
 	nameQuery := fmt.Sprintf("%s-%%", testConfig.GetNamePrefix())

--- a/scripts/mysql/create_routes_and_route_mappings_for_app.tmpl.sql
+++ b/scripts/mysql/create_routes_and_route_mappings_for_app.tmpl.sql
@@ -1,0 +1,36 @@
+CREATE PROCEDURE create_routes_and_route_mappings_for_app(
+    IN app_guid VARCHAR(255),
+    IN org_name VARCHAR(255),
+    IN space_guid VARCHAR(255),
+    IN num_route_mappings INT)
+BEGIN
+    DECLARE default_domain_id INT;
+    DECLARE space_id INT;
+    DECLARE quota_id INT;
+    DECLARE route_guid VARCHAR(255);
+    DECLARE route_mapping_guid VARCHAR(255);
+    DECLARE process_type VARCHAR(20);
+    DECLARE i INT;
+
+    SET default_domain_id = 1;
+    SET process_type = 'web';
+    SET i = 1;
+
+    SELECT quota_definition_id INTO quota_id FROM organizations WHERE name = org_name;
+    UPDATE quota_definitions SET total_routes = -1 WHERE id = quota_id;
+
+    SELECT id INTO space_id FROM spaces WHERE guid = space_guid;
+
+    START TRANSACTION;
+        WHILE i <= num_route_mappings DO
+--          shorten guid to be able to map more routes to the app (diego limitation)
+            SET route_guid = (SELECT LEFT(UUID(), 13));
+            INSERT INTO routes (guid, domain_id, space_id, host) VALUES (route_guid, default_domain_id, space_id, CONCAT('{{.Prefix}}-', route_guid));
+
+            SET route_mapping_guid = (SELECT UUID());
+            INSERT INTO route_mappings (guid, app_guid, route_guid, process_type) VALUES (route_mapping_guid, app_guid, route_guid, process_type);
+
+            SET i = i + 1;
+        END WHILE;
+    COMMIT;
+END;


### PR DESCRIPTION
Adding performance tests for POST, PATCH, DELETE /v3/routes/:guid/destinations.

Diego seems to have a limitation somewhere between 750 and 800 routes per app. At least the app does not start anymore if I create 800 route mappings. With 10000 route mappings the staging already failed.