### PR TITLE
Add service instance tests

### DIFF
--- a/helpers/database.go
+++ b/helpers/database.go
@@ -311,6 +311,19 @@ func ExecuteSelectStatementOneRow(db *sql.DB, ctx context.Context, statement str
 	return result
 }
 
+func ExecuteSelectStatementOneRowString(db *sql.DB, ctx context.Context, statement string) string {
+	var result string
+	err := db.QueryRowContext(ctx, statement).Scan(&result)
+	switch {
+	case err == sql.ErrNoRows:
+		log.Fatalf("query %s returned no value", statement)
+	case err != nil:
+		log.Fatalf("query %s failed with %v", statement, err)
+	}
+
+	return result
+}
+
 func ConvertToString(input interface{}) string {
 	if result, ok := input.(string); ok {
 		return result

--- a/scripts/mysql/create_service_instance_shares.tmpl.sql
+++ b/scripts/mysql/create_service_instance_shares.tmpl.sql
@@ -1,0 +1,64 @@
+DROP PROCEDURE IF EXISTS create_service_instance_shares;
+
+CREATE PROCEDURE create_service_instance_shares(
+    IN orgs INT, 
+    IN spacesPerOrg INT, 
+    IN serviceInstanceSharesPerSpace INT, 
+    IN namePrefix VARCHAR(255)
+)
+BEGIN
+    DECLARE i INT DEFAULT 0;
+    DECLARE j INT DEFAULT 0;
+    DECLARE k INT DEFAULT 0;
+    DECLARE spaceOffset INT;
+    DECLARE spaceId INT;
+    DECLARE shareSpaceGuid VARCHAR(255);
+    DECLARE serviceInstanceGuid VARCHAR(255);
+
+    -- Loop through organizations
+    WHILE i < orgs DO
+        SET j = 0;
+        
+        -- Loop through spaces per organization
+        WHILE j < spacesPerOrg DO
+            -- Calculate spaceOffset and get spaceId
+            SET spaceOffset = i * spacesPerOrg + j;
+
+            -- Get spaceId
+            SELECT id INTO spaceId
+            FROM spaces
+            WHERE name LIKE CONCAT(namePrefix, '-space-%')
+            LIMIT 1 OFFSET spaceOffset;
+
+            SET k = 0;
+            -- Loop through the service instance shares
+            WHILE k < serviceInstanceSharesPerSpace DO
+                -- Find a random space to share that isn't our space
+                SELECT guid INTO shareSpaceGuid
+                FROM spaces
+                WHERE name LIKE CONCAT(namePrefix, '-space-%')
+                AND id != spaceId
+                ORDER BY RAND()
+                LIMIT 1;
+
+                -- Find service instance for the current space
+                SELECT service_instances.guid INTO serviceInstanceGuid
+                FROM service_instances
+                JOIN spaces ON service_instances.space_id = spaces.id
+                WHERE spaces.id = spaceId
+                AND service_instances.name LIKE CONCAT(namePrefix, '-service-instance-%')
+                LIMIT 1 OFFSET k;
+
+                -- Create the share for the service instance
+                INSERT INTO service_instance_shares (service_instance_guid, target_space_guid)
+                VALUES (serviceInstanceGuid, shareSpaceGuid);
+
+                SET k = k + 1;
+            END WHILE;
+
+            SET j = j + 1;
+        END WHILE;
+
+        SET i = i + 1;
+    END WHILE;
+END;

--- a/scripts/mysql/create_service_instances_in_orgs_spaces.tmpl.sql
+++ b/scripts/mysql/create_service_instances_in_orgs_spaces.tmpl.sql
@@ -1,0 +1,57 @@
+DROP PROCEDURE IF EXISTS create_service_instances_for_orgs_spaces_plans;
+
+CREATE PROCEDURE create_service_instances_for_orgs_spaces_plans(
+    IN orgs INT, 
+    IN spacesPerOrg INT, 
+    IN servicePlans INT, 
+    IN instancesPerPlanPerSpace INT, 
+    IN namePrefix VARCHAR(255)
+)
+BEGIN
+    DECLARE i INT DEFAULT 0;
+    DECLARE j INT DEFAULT 0;
+    DECLARE k INT DEFAULT 0;
+    DECLARE spaceOffset INT;
+    DECLARE servicePlanOffset INT;
+    DECLARE spaceId INT;
+    DECLARE servicePlanId INT;
+
+    -- Loop through organizations
+    WHILE i < orgs DO
+        SET j = 0;
+        
+        -- Loop through spaces per organization
+        WHILE j < spacesPerOrg DO
+            -- Calculate spaceOffset
+            SET spaceOffset = i * spacesPerOrg + j;
+
+            -- Get spaceId
+            SELECT id INTO spaceId
+            FROM spaces
+            WHERE name LIKE CONCAT(namePrefix, '-space-%')
+            LIMIT 1 OFFSET spaceOffset;
+
+            SET k = 0;
+            -- Loop through service plans
+            WHILE k < servicePlans DO
+                -- Calculate servicePlanOffset
+                SET servicePlanOffset = k;
+
+                -- Get servicePlanId
+                SELECT id INTO servicePlanId
+                FROM service_plans
+                WHERE name LIKE CONCAT(namePrefix, '-service-plan-%')
+                LIMIT 1 OFFSET servicePlanOffset;
+
+                -- Call the stored procedure to create service instances
+                CALL create_service_instances(spaceId, servicePlanId, instancesPerPlanPerSpace);
+
+                SET k = k + 1;
+            END WHILE;
+
+            SET j = j + 1;
+        END WHILE;
+
+        SET i = i + 1;
+    END WHILE;
+END;

--- a/scripts/mysql/create_services_and_plans.tmpl.sql
+++ b/scripts/mysql/create_services_and_plans.tmpl.sql
@@ -17,26 +17,28 @@ BEGIN
         DO
             SET services_counter = services_counter + 1;
             SET service_guid = UUID();
-            INSERT INTO services (guid, label, description, bindable, service_broker_id)
+            INSERT INTO services (guid, label, description, bindable, service_broker_id, extra)
             VALUES (service_guid,
                     CONCAT('{{.Prefix}}-service-', service_guid),
                     CONCAT('{{.Prefix}}-service-description-', service_guid),
                     service_bindable,
-                    service_broker_id);
+                    service_broker_id,
+                    '{"shareable": true}');
             SET latest_service_id = LAST_INSERT_ID();
             SET service_plans_counter = 0;
             WHILE service_plans_counter < num_service_plans
                 DO
                     SET service_plans_counter = service_plans_counter + 1;
                     SET service_plan_guid := UUID();
-                    INSERT INTO service_plans (guid, name, description, free, service_id, unique_id, public)
+                    INSERT INTO service_plans (guid, name, description, free, service_id, unique_id, public, extra)
                     VALUES (service_plan_guid,
                             CONCAT('{{.Prefix}}-service-plan-', service_plan_guid),
                             CONCAT('{{.Prefix}}-service-plan-description-', service_plan_guid),
                             service_plan_free,
                             latest_service_id,
                             CONCAT('unique-', service_plan_guid),
-                            service_plan_public);
+                            service_plan_public,
+                            '{"shareable": true}');
                     SET latest_service_plan_id = LAST_INSERT_ID();
                     INSERT INTO service_plan_visibilities (guid, service_plan_id, organization_id)
                     SELECT UUID(), latest_service_plan_id, id

--- a/service_instances/v1/service_instances_suite_test.go
+++ b/service_instances/v1/service_instances_suite_test.go
@@ -1,0 +1,126 @@
+package service_instances
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+)
+
+var testConfig = helpers.NewConfig()
+var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
+var ccdb *sql.DB
+var uaadb *sql.DB
+var ctx context.Context
+
+const test_version = "v1"
+
+const (
+	orgs                          = 10
+	spacesPerOrg                  = 20
+	serviceInstancesPerSpace      = 200 // 10 x 20 x 200 = 40000 service instances
+	serviceInstanceSharesPerSpace = 20  // 10 x 20 x 20 = 4000 service instance shares
+
+	serviceOfferings        = 2
+	servicePlansPerOffering = 5 // 2 x 5 = 10 service plans
+)
+
+var _ = BeforeSuite(func() {
+	testSetup = workflowhelpers.NewTestSuiteSetup(&testConfig)
+	testSetup.Setup()
+	ccdb, uaadb, ctx = helpers.OpenDbConnections(testConfig)
+	fmt.Printf("%v Starting to seed database with testdata...\n", time.Now().Format(time.RFC850))
+
+	helpers.ImportStoredProcedures(ccdb, ctx, testConfig)
+	serviceBrokerId := createServiceBroker(testConfig.GetNamePrefix())
+
+	log.Printf("Stored procedures imported")
+
+	createOrgStatement := fmt.Sprintf("create_orgs(%d)", orgs)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createOrgStatement, testConfig)
+
+	orgsAssignedToRegularUser := orgs / 2
+
+	selectOrgsRandomlyStatement := fmt.Sprintf("create_selected_orgs_table(%d)", orgsAssignedToRegularUser)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, selectOrgsRandomlyStatement, testConfig)
+
+	log.Printf("Creating service offerings and plans...")
+	createPublicServicePlansStatement := fmt.Sprintf("create_services_and_plans(%v, %v, %v, %v, %v)",
+		serviceOfferings, serviceBrokerId, servicePlansPerOffering, true, 0)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createPublicServicePlansStatement, testConfig)
+
+	// create spaces
+	createSpacesStatement := fmt.Sprintf("create_spaces(%d)", spacesPerOrg)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createSpacesStatement, testConfig)
+
+	servicePlans := serviceOfferings * servicePlansPerOffering
+	instancesPerPlanPerSpace := serviceInstancesPerSpace / servicePlans
+
+	// create instances
+	createServiceInstancesStatement := fmt.Sprintf("create_service_instances_for_orgs_spaces_plans(%d, %d, %d, %d, '%s')", orgs, spacesPerOrg, servicePlans, instancesPerPlanPerSpace, testConfig.GetNamePrefix())
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createServiceInstancesStatement, testConfig)
+
+	// create service instance shares
+	createServiceInstanceShareStatement := fmt.Sprintf("create_service_instance_shares(%d, %d, %d, '%s')", orgs, spacesPerOrg, instancesPerPlanPerSpace, testConfig.GetNamePrefix())
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createServiceInstanceShareStatement, testConfig)
+
+	// assign org_manager to the user for half the number of created orgs randomly
+	// assign space_developer rights to the user for all spaces within the orgs where the user received permissions
+	regularUserGUID := helpers.GetUserGUID(testSetup.RegularUserContext(), testConfig)
+
+	assignUserAsOrgManager := fmt.Sprintf("assign_user_as_org_role('%s', '%s', %d)", regularUserGUID, "organizations_managers", orgsAssignedToRegularUser)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, assignUserAsOrgManager, testConfig)
+	spacesAssignedToRegularUser := orgs * spacesPerOrg / 2
+	assignUserAsSpaceDeveloper := fmt.Sprintf("assign_user_as_space_role('%s', '%s', %d)", regularUserGUID, "spaces_developers", spacesAssignedToRegularUser)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, assignUserAsSpaceDeveloper, testConfig)
+
+	helpers.AnalyzeDB(ccdb, ctx, testConfig)
+	fmt.Printf("%v Finished seeding database.\n", time.Now().Format(time.RFC850))
+})
+
+var _ = AfterSuite(func() {
+	fmt.Printf("%v Starting cleanup testdata...\n", time.Now().Format(time.RFC850))
+	helpers.CleanupTestData(ccdb, uaadb, ctx, testConfig)
+	fmt.Printf("%v Finished cleanup testdata...\n", time.Now().Format(time.RFC850))
+	err := ccdb.Close()
+	if err != nil {
+		log.Print(err)
+	}
+
+	if uaadb != nil {
+		err = uaadb.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}
+})
+
+var _ = ReportAfterSuite("Service instances test suite", func(report types.Report) {
+	helpers.GenerateReports(helpers.ConfigureJsonReporter(&testConfig, "service-instances", "service instances", test_version), report)
+})
+
+func TestServiceInstances(t *testing.T) {
+	helpers.LoadConfig(&testConfig)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Service instances Test Suite")
+}
+
+func createServiceBroker(prefix string) int {
+	serviceBrokerGuid := uuid.NewString()
+	serviceBrokerName := fmt.Sprintf("%s-service-broker-%s", prefix, serviceBrokerGuid)
+	createServiceBrokerStatement := fmt.Sprintf(
+		"INSERT INTO service_brokers (guid, name, broker_url, auth_password) VALUES ('%s', '%s', '', '')",
+		serviceBrokerGuid, serviceBrokerName)
+	return helpers.ExecuteInsertStatement(ccdb, ctx, createServiceBrokerStatement, testConfig)
+}

--- a/service_instances/v1/service_instances_test.go
+++ b/service_instances/v1/service_instances_test.go
@@ -1,0 +1,257 @@
+package service_instances
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gmeasure"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+)
+
+var _ = Describe("service instances", func() {
+	Describe("GET /v3/service_instances", func() {
+		Context("as admin", func() {
+			It("lists all /v3/service_instances", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances::as admin::list all")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("GET /v3/service_instances", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, "/v3/service_instances")
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("list all /v3/service_instances with a large page size", func() {
+				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_instances::as admin::list with a page size %d", testConfig.LargePageSize))
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("GET /v3/service_instances", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf("/v3/service_instances?per_page=%d", testConfig.LargePageSize))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("list all /v3/service_instances getting the last page", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances::as admin::list getting the last page")
+				AddReportEntry(experiment.Name, experiment)
+
+				var pages int
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+					exitCode, body := helpers.TimeCFCurlReturning(testConfig.LongTimeout, "/v3/service_instances")
+					Expect(exitCode).To(Equal(0))
+					Expect(body).To(ContainSubstring("200 OK"))
+					response := helpers.ParseResponseBody(helpers.RemoveDebugOutput(body))
+					pages = response.Pagination.TotalPages
+				})
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("GET /v3/service_instances", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf("/v3/service_instances?page=%d", pages))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+
+		Context("as regular user", func() {
+			It("lists all /v3/service_instances", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances::as regular user::list all")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.RegularUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						experiment.MeasureDuration("GET /v3/service_instances", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, "/v3/service_instances")
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+	})
+
+	Describe("GET /v3/service_instances?org_guids=", func() {
+		Context("as admin", func() {
+			It("filters by a single of organization_guids", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances?org_guids==::as admin::filter by a single organization_guid")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						orgGuidList := getRandomOrgGuids()
+
+						experiment.MeasureDuration("GET /v3/service_instances?organization_guids=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?organization_guids=%v", orgGuidList[0]))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("filters by a list of organization_guids with a large page size", func() {
+				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_instances?organization_guids==::as admin::filter for list of organization_guids with a page size %d", testConfig.LargePageSize))
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						orgGuidList := getRandomOrgGuids()
+
+						experiment.MeasureDuration("GET /v3/service_instances?organization_guids=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?per_page=%d&organization_guids=%v", testConfig.LargePageSize, strings.Join(orgGuidList[:], ",")))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+	})
+
+	Describe("GET /v3/service_instances?space_guids=", func() {
+		Context("as admin", func() {
+			It("filters by a single of space_guid", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances?space_guids==::as admin::filter by a single space_guid")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						spaceGuidList := getRandomSpaceGuids()
+
+						experiment.MeasureDuration("GET /v3/service_instances?space_guids=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?per_page=%d&space_guids=%v", testConfig.LargePageSize, spaceGuidList[0]))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("filters by a list of space_guids with a large page size", func() {
+				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_instances?space_guids==::as admin::filter for list of space_guids with a page size %d", testConfig.LargePageSize))
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						spaceGuidList := getRandomSpaceGuids()
+
+						experiment.MeasureDuration("GET /v3/service_instances?space_guids=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?&space_guids=%v", strings.Join(spaceGuidList[:], ",")))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+	})
+
+	Describe("GET /v3/service_instances?service_plan_guids=", func() {
+		Context("as admin", func() {
+			It("filters by a single service_plan_guid", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances?service_plan_guids==::as admin::filters by a single service_plan_guid")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						servicePlanGuidsList := getRandomServicePlanGuids()
+
+						experiment.MeasureDuration("GET /v3/service_instances?service_plan_guids=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?service_plan_guids=%v", servicePlanGuidsList[0]))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("filters for list of service_plan_guids with a large page size", func() {
+				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_instances?service_plan_guids==::as admin::filter for list of service_plan_guids with a page size %d", testConfig.LargePageSize))
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						servicePlanGuidsList := getRandomServicePlanGuids()
+
+						experiment.MeasureDuration("GET /v3/service_instances?service_plan_guids=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?per_page=%d&service_plan_guids=%v", testConfig.LargePageSize, strings.Join(servicePlanGuidsList[:], ",")))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+	})
+
+	Describe("GET /v3/service_instances?service_plan_names=", func() {
+		Context("as admin", func() {
+			It("filters by a single service_plan_name", func() {
+				experiment := gmeasure.NewExperiment("GET /v3/service_instances?service_plan_names==::as admin::filters by a single service_plan_name")
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						servicePlanNamesList := getRandomServicePlanNames()
+
+						experiment.MeasureDuration("GET /v3/service_instances?service_plan_names=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?service_plan_names=%v", strings.Join(servicePlanNamesList[:], ",")))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+
+			It("filters for list of service_plan_names with a large page size", func() {
+				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_instances?service_plan_names==::as admin::filter for list of service_plan_names with a page size %d", testConfig.LargePageSize))
+				AddReportEntry(experiment.Name, experiment)
+
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
+					experiment.Sample(func(idx int) {
+						servicePlanNamesList := getRandomServicePlanNames()
+
+						experiment.MeasureDuration("GET /v3/service_instances?service_plan_names=:guid", func() {
+							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
+								"/v3/service_instances?per_page=%d&service_plan_names=%v", testConfig.LargePageSize, strings.Join(servicePlanNamesList[:], ",")))
+						})
+					}, gmeasure.SamplingConfig{N: testConfig.Samples})
+				})
+			})
+		})
+	})
+})
+
+func getRandomOrgGuids() []string {
+	return getRandomRows("guid", "organizations", fmt.Sprintf("%s-org", testConfig.GetNamePrefix()), 5)
+}
+
+func getRandomSpaceGuids() []string {
+	return getRandomRows("guid", "spaces", fmt.Sprintf("%s-space", testConfig.GetNamePrefix()), 5)
+}
+
+func getRandomServicePlanGuids() []string {
+	return getRandomRows("guid", "service_plans", fmt.Sprintf("%s-service-plan", testConfig.GetNamePrefix()), 5)
+}
+
+func getRandomServicePlanNames() []string {
+	return getRandomRows("name", "service_plans", fmt.Sprintf("%s-service-plan", testConfig.GetNamePrefix()), 5)
+}
+
+func getRandomRows(column string, tableName string, namePrefix string, limit int) []string {
+	var list []string = nil
+	statement := fmt.Sprintf("SELECT %s FROM %s WHERE name LIKE '%s-%%' ORDER BY %s LIMIT %d", column, tableName, namePrefix, helpers.GetRandomFunction(testConfig), limit)
+
+	cols := helpers.ExecuteSelectStatement(ccdb, ctx, statement)
+	for _, guid := range cols {
+		list = append(list, helpers.ConvertToString(guid))
+	}
+
+	Expect(len(list)).To(Equal(limit))
+
+	return list
+}


### PR DESCRIPTION
* 20 orgs each with 20 spaces
* 10 service plans
* 40000 service instances
* 4000 service instance shares

Example output:

```
Will run 12 of 12 specs
Tuesday, 19-Nov-24 14:04:59 MST Starting to seed database with testdata...
2024/11/19 14:04:59 Opening database connection to postgres...
2024/11/19 14:04:59 Stored procedures imported
2024/11/19 14:04:59 Executing stored procedure: SELECT FROM create_orgs(10)
2024/11/19 14:05:00 Finished stored procedure: SELECT FROM create_orgs(10)
2024/11/19 14:05:00 Executing stored procedure: SELECT FROM create_selected_orgs_table(5)
2024/11/19 14:05:00 Finished stored procedure: SELECT FROM create_selected_orgs_table(5)
2024/11/19 14:05:00 Creating service offerings and plans...
2024/11/19 14:05:00 Executing stored procedure: SELECT FROM create_services_and_plans(2, 8, 5, true, 0)
2024/11/19 14:05:00 Finished stored procedure: SELECT FROM create_services_and_plans(2, 8, 5, true, 0)
2024/11/19 14:05:00 Executing stored procedure: SELECT FROM create_spaces(20)
2024/11/19 14:05:00 Finished stored procedure: SELECT FROM create_spaces(20)
2024/11/19 14:05:00 Executing stored procedure: SELECT FROM create_service_instances_for_orgs_spaces_plans(10, 20, 10, 20, 'perf')
2024/11/19 14:05:04 Finished stored procedure: SELECT FROM create_service_instances_for_orgs_spaces_plans(10, 20, 10, 20, 'perf')
2024/11/19 14:05:04 Executing stored procedure: SELECT FROM create_service_instance_shares(10, 20, 20, 'perf')
2024/11/19 14:05:06 Finished stored procedure: SELECT FROM create_service_instance_shares(10, 20, 20, 'perf')
2024/11/19 14:05:08 Executing stored procedure: SELECT FROM assign_user_as_org_role('9cca654e-b513-4520-a330-5960b35f47f3', 'organizations_managers', 5)
2024/11/19 14:05:08 Finished stored procedure: SELECT FROM assign_user_as_org_role('9cca654e-b513-4520-a330-5960b35f47f3', 'organizations_managers', 5)
2024/11/19 14:05:08 Executing stored procedure: SELECT FROM assign_user_as_space_role('9cca654e-b513-4520-a330-5960b35f47f3', 'spaces_developers', 100)
2024/11/19 14:05:08 Finished stored procedure: SELECT FROM assign_user_as_space_role('9cca654e-b513-4520-a330-5960b35f47f3', 'spaces_developers', 100)
2024/11/19 14:05:08 Tuesday, 19-Nov-24 14:05:08 MST Running 'ANALYZE' on db...
2024/11/19 14:05:13 Tuesday, 19-Nov-24 14:05:13 MST Waiting for Database to stabalize
Tuesday, 19-Nov-24 14:07:13 MST Finished seeding database.
------------------------------
• [4.300 seconds]
service instances GET /v3/service_instances as admin lists all /v3/service_instances
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:19

  Begin Report Entries >>
    GET /v3/service_instances::as admin::list all - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:21 @ 11/19/24 14:07:13.865
      GET /v3/service_instances::as admin::list all
      Name                                 | N | Min   | Median  | Mean  | StdDev | Max    
      =====================================================================================
      GET /v3/service_instances [duration] | 5 | 633ms | 661.8ms | 682ms | 53.6ms | 778.2ms
  << End Report Entries
------------------------------
• [SLOW TEST] [7.571 seconds]
service instances GET /v3/service_instances as admin list all /v3/service_instances with large page size
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:32

  Begin Report Entries >>
    GET /v3/service_instances::as admin::list with page size 500 - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:34 @ 11/19/24 14:07:18.166
      GET /v3/service_instances::as admin::list with page size 500
      Name                                 | N | Min     | Median  | Mean    | StdDev  | Max    
      ==========================================================================================
      GET /v3/service_instances [duration] | 5 | 1.0981s | 1.1849s | 1.3396s | 349.3ms | 2.0341s
  << End Report Entries
------------------------------
• [SLOW TEST] [5.611 seconds]
service instances GET /v3/service_instances as admin list all /v3/service_instances getting the last page
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:45

  Begin Report Entries >>
    GET /v3/service_instances::as admin::list getting the last page - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:47 @ 11/19/24 14:07:25.738
      GET /v3/service_instances::as admin::list getting the last page
      Name                                 | N | Min     | Median | Mean    | StdDev | Max  
      ======================================================================================
      GET /v3/service_instances [duration] | 5 | 649.2ms | 661ms  | 660.3ms | 6.8ms  | 668ms
  << End Report Entries
------------------------------
• [4.642 seconds]
service instances GET /v3/service_instances as regular user lists all /v3/service_instances
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:69

  Begin Report Entries >>
    GET /v3/service_instances::as regular user::list all - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:71 @ 11/19/24 14:07:31.35
      GET /v3/service_instances::as regular user::list all
      Name                                 | N | Min     | Median  | Mean    | StdDev | Max    
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 654.1ms | 670.7ms | 684.9ms | 38.6ms | 760.4ms
  << End Report Entries
------------------------------
• [4.411 seconds]
service instances GET /v3/service_instances?org_guids= as admin filters by a single of organization_guids
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:86

  Begin Report Entries >>
    GET /v3/service_instances?org_guids==::as admin::filter by a single of organization_guids - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:88 @ 11/19/24 14:07:35.992
      GET /v3/service_instances?org_guids==::as admin::filter by a single of organization_guids
      Name                                                          | N | Min     | Median  | Mean    | StdDev | Max    
      ==================================================================================================================
      GET /v3/service_instances?organization_guids=:guid [duration] | 5 | 598.8ms | 657.8ms | 649.2ms | 28.8ms | 682.5ms
  << End Report Entries
------------------------------
• [SLOW TEST] [6.844 seconds]
service instances GET /v3/service_instances?org_guids= as admin filters by a list of organization_guids with large page size
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:102

  Begin Report Entries >>
    GET /v3/service_instances?organization_guids==::as admin::filter for list of organization_guids with large page size - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:104 @ 11/19/24 14:07:40.403
      GET /v3/service_instances?organization_guids==::as admin::filter for list of organization_guids with large page size
      Name                                                          | N | Min     | Median  | Mean    | StdDev | Max    
      ==================================================================================================================
      GET /v3/service_instances?organization_guids=:guid [duration] | 5 | 1.0726s | 1.1481s | 1.1489s | 53.6ms | 1.2371s
  << End Report Entries
------------------------------
• [SLOW TEST] [5.166 seconds]
service instances GET /v3/service_instances?space_guids= as admin filters by a single of space_guid
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:122

  Begin Report Entries >>
    GET /v3/service_instances?space_guids==::as admin::filter by a single of space_guid - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:124 @ 11/19/24 14:07:47.249
      GET /v3/service_instances?space_guids==::as admin::filter by a single of space_guid
      Name                                                   | N | Min     | Median  | Mean    | StdDev | Max    
      ===========================================================================================================
      GET /v3/service_instances?space_guids=:guid [duration] | 5 | 681.7ms | 709.2ms | 738.3ms | 58.3ms | 816.5ms
  << End Report Entries
------------------------------
• [4.509 seconds]
service instances GET /v3/service_instances?space_guids= as admin filters by a list of space_guids with large page size
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:138

  Begin Report Entries >>
    GET /v3/service_instances?space_guids==::as admin::filter for list of space_guids with large page size - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:140 @ 11/19/24 14:07:52.417
      GET /v3/service_instances?space_guids==::as admin::filter for list of space_guids with large page size
      Name                                                   | N | Min     | Median  | Mean    | StdDev | Max    
      ===========================================================================================================
      GET /v3/service_instances?space_guids=:guid [duration] | 5 | 627.4ms | 660.1ms | 665.4ms | 27.6ms | 708.6ms
  << End Report Entries
------------------------------
• [4.166 seconds]
service instances GET /v3/service_instances?service_plan_guids= as admin filters by a single service_plan_guid
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:158

  Begin Report Entries >>
    GET /v3/service_instances?service_plan_guids==::as admin::filters by a single service_plan_guid - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:160 @ 11/19/24 14:07:56.926
      GET /v3/service_instances?service_plan_guids==::as admin::filters by a single service_plan_guid
      Name                                                          | N | Min     | Median  | Mean    | StdDev | Max    
      ==================================================================================================================
      GET /v3/service_instances?service_plan_guids=:guid [duration] | 5 | 506.1ms | 587.4ms | 587.2ms | 68.5ms | 707.4ms
  << End Report Entries
------------------------------
• [SLOW TEST] [11.476 seconds]
service instances GET /v3/service_instances?service_plan_guids= as admin filters for list of service_plan_guids with large page size
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:174

  Begin Report Entries >>
    GET /v3/service_instances?service_plan_guids==::as admin::filter for list of service_plan_guids with large page size - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:176 @ 11/19/24 14:08:01.094
      GET /v3/service_instances?service_plan_guids==::as admin::filter for list of service_plan_guids with large page size
      Name                                                          | N | Min     | Median  | Mean    | StdDev  | Max    
      ===================================================================================================================
      GET /v3/service_instances?service_plan_guids=:guid [duration] | 5 | 1.2929s | 1.9494s | 2.0563s | 753.4ms | 3.4496s
  << End Report Entries
------------------------------
• [SLOW TEST] [5.970 seconds]
service instances GET /v3/service_instances?service_plan_names= as admin filters by a single service_plan_name
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:194

  Begin Report Entries >>
    GET /v3/service_instances?service_plan_names==::as admin::filters by a single service_plan_name - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:196 @ 11/19/24 14:08:12.572
      GET /v3/service_instances?service_plan_names==::as admin::filters by a single service_plan_name
      Name                                                          | N | Min     | Median  | Mean  | StdDev  | Max    
      =================================================================================================================
      GET /v3/service_instances?service_plan_names=:guid [duration] | 5 | 628.6ms | 847.4ms | 877ms | 250.5ms | 1.3364s
  << End Report Entries
------------------------------
• [SLOW TEST] [11.804 seconds]
service instances GET /v3/service_instances?service_plan_names= as admin filters for list of service_plan_names with large page size
/Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:210

  Begin Report Entries >>
    GET /v3/service_instances?service_plan_names==::as admin::filter for list of service_plan_names with large page size - /Users/sgunaratne/workspace/cf-performance-tests/service_instances/v1/service_instances_test.go:212 @ 11/19/24 14:08:18.543
      GET /v3/service_instances?service_plan_names==::as admin::filter for list of service_plan_names with large page size
      Name                                                          | N | Min     | Median  | Mean    | StdDev | Max    
      ==================================================================================================================
      GET /v3/service_instances?service_plan_names=:guid [duration] | 5 | 1.1942s | 2.0475s | 2.1203s | 776ms  | 3.5114s
  << End Report Entries
------------------------------
Tuesday, 19-Nov-24 14:08:30 MST Starting cleanup testdata...
2024/11/19 14:08:30 Tuesday, 19-Nov-24 14:08:30 MST Cleaning up db...
2024/11/19 14:08:36 Tuesday, 19-Nov-24 14:08:36 MST Running 'VACUUM FULL' on db...
Tuesday, 19-Nov-24 14:08:39 MST Finished cleanup testdata...

Ran 12 of 12 Specs in 227.278 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```