### PR TITLE
Service plans suite v3

### DIFF
--- a/helpers/database.go
+++ b/helpers/database.go
@@ -227,7 +227,7 @@ func AnalyzeDB(ccdb *sql.DB, ctx context.Context, testConfig Config) {
 		ExecuteStatement(ccdb, ctx, "VACUUM FULL;")
 		ExecuteStatement(ccdb, ctx, "ANALYZE;")
 	}
-	log.Printf("%v Waiting for Database to stabalize\n", time.Now().Format(time.RFC850))
+	log.Printf("%v Waiting for Database to stabilize\n", time.Now().Format(time.RFC850))
 	time.Sleep(120 * time.Second)
 }
 

--- a/scripts/mysql/create_services_and_plans.tmpl.sql
+++ b/scripts/mysql/create_services_and_plans.tmpl.sql
@@ -2,16 +2,30 @@ CREATE PROCEDURE create_services_and_plans(num_services INT,
                                            service_broker_id INT,
                                            num_service_plans INT,
                                            service_plan_public BOOLEAN,
-                                           num_visible_orgs INT)
+                                           num_visible_orgs INT,
+                                           with_boilerplate BOOLEAN)
 BEGIN
     DECLARE service_guid VARCHAR(255);
     DECLARE service_bindable BOOLEAN DEFAULT TRUE;
     DECLARE service_plan_guid VARCHAR(255);
     DECLARE services_counter INT DEFAULT 0;
+    DECLARE boilerplate TEXT;
     DECLARE service_plan_free BOOLEAN DEFAULT TRUE;
     DECLARE service_plans_counter INT DEFAULT 0;
     DECLARE latest_service_id INT;
     DECLARE latest_service_plan_id INT;
+
+    IF with_boilerplate = true THEN
+        SET boilerplate = CONCAT('Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+                                 'Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.',
+                                 'Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.',
+                                 'Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.',
+                                 'Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis.',
+                                 'At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, At accusam aliquyam diam diam dolore dolores duo eirmod eos erat, et nonumy sed tempor et et invidunt justo labore Stet clita ea et gubergren, kasd magna no rebum. sanctus sea sed takimata ut vero voluptua. est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.',
+                                 'Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus.');
+    ELSE
+        SET boilerplate = '';
+    END IF;
 
     WHILE services_counter < num_services
         DO
@@ -30,15 +44,18 @@ BEGIN
                 DO
                     SET service_plans_counter = service_plans_counter + 1;
                     SET service_plan_guid := UUID();
-                    INSERT INTO service_plans (guid, name, description, free, service_id, unique_id, public, extra)
+                    INSERT INTO service_plans (guid, name, description, free, service_id, unique_id, public, extra, create_instance_schema, update_instance_schema, create_binding_schema)
                     VALUES (service_plan_guid,
                             CONCAT('{{.Prefix}}-service-plan-', service_plan_guid),
-                            CONCAT('{{.Prefix}}-service-plan-description-', service_plan_guid),
+                            CONCAT('{{.Prefix}}-service-plan-description-', service_plan_guid, boilerplate),
                             service_plan_free,
                             latest_service_id,
                             CONCAT('unique-', service_plan_guid),
                             service_plan_public,
-                            '{"shareable": true}');
+                            '{"shareable": true}',
+                            boilerplate,
+                            boilerplate,
+                            boilerplate);
                     SET latest_service_plan_id = LAST_INSERT_ID();
                     INSERT INTO service_plan_visibilities (guid, service_plan_id, organization_id)
                     SELECT UUID(), latest_service_plan_id, id

--- a/service_instances/v1/service_instances_suite_test.go
+++ b/service_instances/v1/service_instances_suite_test.go
@@ -56,8 +56,8 @@ var _ = BeforeSuite(func() {
 	helpers.ExecuteStoredProcedure(ccdb, ctx, selectOrgsRandomlyStatement, testConfig)
 
 	log.Printf("Creating service offerings and plans...")
-	createPublicServicePlansStatement := fmt.Sprintf("create_services_and_plans(%v, %v, %v, %v, %v)",
-		serviceOfferings, serviceBrokerId, servicePlansPerOffering, true, 0)
+	createPublicServicePlansStatement := fmt.Sprintf("create_services_and_plans(%v, %v, %v, %v, %v, %v)",
+		serviceOfferings, serviceBrokerId, servicePlansPerOffering, true, 0, false)
 	helpers.ExecuteStoredProcedure(ccdb, ctx, createPublicServicePlansStatement, testConfig)
 
 	// create spaces

--- a/service_plans/v3/service_plans_test.go
+++ b/service_plans/v3/service_plans_test.go
@@ -28,7 +28,7 @@ var _ = Describe("service plans", func() {
 			})
 		})
 
-		It("list all /v3/service_plans as admin with large page size", func() {
+		It("lists all /v3/service_plans as admin with large page size", func() {
 			experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_plans::as admin::list with page size %d", testConfig.LargePageSize))
 			AddReportEntry(experiment.Name, experiment)
 
@@ -74,7 +74,7 @@ var _ = Describe("service plans", func() {
 		})
 
 		Context("as regular user", func() {
-			It("shows one /v3/service_plans/:guid as user", func() {
+			It("shows one /v3/service_plans/:guid as regular user", func() {
 				experiment := gmeasure.NewExperiment("GET /v3/service_plans/:guid::as regular user::show one")
 				AddReportEntry(experiment.Name, experiment)
 
@@ -199,23 +199,6 @@ var _ = Describe("service plans", func() {
 					}, gmeasure.SamplingConfig{N: testConfig.Samples})
 				})
 			})
-
-			It(fmt.Sprintf("filters for list of service_instances with page size %d", testConfig.LargePageSize), func() {
-				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_plans?service_instance_guids=::as admin::filter for list of service_instances with page size %d", testConfig.LargePageSize))
-				AddReportEntry(experiment.Name, experiment)
-
-				workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.BasicTimeout, func() {
-					experiment.Sample(func(idx int) {
-						serviceInstanceGuidsList := getRandomServiceInstanceGUIDs()
-
-						experiment.MeasureDuration("GET /v3/service_plans?service_instances_guids=:guid", func() {
-							helpers.TimeCFCurl(testConfig.LongTimeout, fmt.Sprintf(
-								"/v3/service_plans?service_instance_guids=%v&per_page=%d",
-								strings.Join(serviceInstanceGuidsList[:], ","), testConfig.LargePageSize))
-						})
-					}, gmeasure.SamplingConfig{N: testConfig.Samples})
-				})
-			})
 		})
 
 		Context("as regular user", func() {
@@ -230,23 +213,6 @@ var _ = Describe("service plans", func() {
 						experiment.MeasureDuration("GET /v3/service_plans?service_instances_guids=:guid", func() {
 							helpers.TimeCFCurl(testConfig.BasicTimeout, fmt.Sprintf(
 								"/v3/service_plans?service_instance_guids=%v", strings.Join(serviceInstanceGuidsList[:], ",")))
-						})
-					}, gmeasure.SamplingConfig{N: testConfig.Samples})
-				})
-			})
-
-			It(fmt.Sprintf("filters for list of service_instances with page size %d", testConfig.LargePageSize), func() {
-				experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/service_plans?service_instance_guids=::as regular user::filter for list of service_instances with page size %d", testConfig.LargePageSize))
-				AddReportEntry(experiment.Name, experiment)
-
-				workflowhelpers.AsUser(testSetup.RegularUserContext(), testConfig.BasicTimeout, func() {
-					experiment.Sample(func(idx int) {
-						serviceInstanceGuidsList := getRandomServiceInstanceGUIDs()
-
-						experiment.MeasureDuration("GET /v3/service_plans?service_instances_guids=:guid", func() {
-							helpers.TimeCFCurl(testConfig.LongTimeout, fmt.Sprintf(
-								"/v3/service_plans?service_instance_guids=%v&per_page=%d",
-								strings.Join(serviceInstanceGuidsList[:], ","), testConfig.LargePageSize))
 						})
 					}, gmeasure.SamplingConfig{N: testConfig.Samples})
 				})
@@ -301,13 +267,13 @@ func getRandomServiceInstanceGUIDs() []string {
 	var serviceInstanceGuidsList []string = nil
 
 	// all service instances are being created in a space the user has access to
-	serviceInstanceStatement := fmt.Sprintf("SELECT guid FROM service_instances WHERE name LIKE '%s-service-instance-%%' ORDER BY %s LIMIT 50", testConfig.GetNamePrefix(), helpers.GetRandomFunction(testConfig))
+	serviceInstanceStatement := fmt.Sprintf("SELECT guid FROM service_instances WHERE name LIKE '%s-service-instance-%%' ORDER BY %s LIMIT 200", testConfig.GetNamePrefix(), helpers.GetRandomFunction(testConfig))
 	serviceInstanceGuids := helpers.ExecuteSelectStatement(ccdb, ctx, serviceInstanceStatement)
 	for _, guid := range serviceInstanceGuids {
 		serviceInstanceGuidsList = append(serviceInstanceGuidsList, helpers.ConvertToString(guid))
 	}
 
-	Expect(len(serviceInstanceGuidsList)).To(Equal(50))
+	Expect(len(serviceInstanceGuidsList)).To(Equal(200))
 
 	return serviceInstanceGuidsList
 }


### PR DESCRIPTION
- New option `with_boilerplate` for `create_services_and_plans` function; adds large text to `description` and additional fields (`create_instance_schema`, `update_instance_schema`, `create_binding_schema`).
- Use 200 instead of 50 service instance guids for filter.
- First choose a single service plan randomly and then a space where this plan is visible.
- Remove tests with large page size as the result list contains a single plan only.