### PR TITLE
Add organizations/v1 perf suite

### DIFF
--- a/organizations/v1/organizations_suite_test.go
+++ b/organizations/v1/organizations_suite_test.go
@@ -1,0 +1,75 @@
+package organizations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+)
+
+var testConfig = helpers.NewConfig()
+var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
+var ccdb *sql.DB
+var uaadb *sql.DB
+var ctx context.Context
+
+const test_version = "v1"
+
+const (
+	// main test parameters:
+	orgs = 100000
+)
+
+var _ = BeforeSuite(func() {
+	testSetup = workflowhelpers.NewTestSuiteSetup(&testConfig)
+	testSetup.Setup()
+	ccdb, uaadb, ctx = helpers.OpenDbConnections(testConfig)
+	helpers.ImportStoredProcedures(ccdb, ctx, testConfig)
+
+	createOrgStatement := fmt.Sprintf("create_orgs(%d)", orgs)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createOrgStatement, testConfig)
+
+	orgsAssignedToRegularUser := orgs / 10
+	selectOrgsStatement := fmt.Sprintf("create_selected_orgs_table(%d)", orgsAssignedToRegularUser)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, selectOrgsStatement, testConfig)
+
+	regularUserGUID := helpers.GetUserGUID(testSetup.RegularUserContext(), testConfig)
+	assignDisjointOrgRoles := fmt.Sprintf("assign_user_disjoint_org_roles('%s')", regularUserGUID)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, assignDisjointOrgRoles, testConfig)
+
+	helpers.AnalyzeDB(ccdb, ctx, testConfig)
+})
+
+var _ = AfterSuite(func() {
+	helpers.CleanupTestData(ccdb, uaadb, ctx, testConfig)
+
+	err := ccdb.Close()
+	if err != nil {
+		log.Print(err)
+	}
+
+	if uaadb != nil {
+		err = uaadb.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}
+})
+
+var _ = ReportAfterSuite("Organizations test suite", func(report types.Report) {
+	helpers.GenerateReports(helpers.ConfigureJsonReporter(&testConfig, "organizations", "organizations", test_version), report)
+})
+
+func TestOrganizations(t *testing.T) {
+	helpers.LoadConfig(&testConfig)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OrganizationsTest Suite")
+}

--- a/organizations/v1/organizations_test.go
+++ b/organizations/v1/organizations_test.go
@@ -1,0 +1,54 @@
+package organizations
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega/gmeasure"
+)
+
+var _ = Describe("organizations", func() {
+	Describe("GET /v3/organizations", func() {
+
+		It("as admin", func() {
+			experiment := gmeasure.NewExperiment("GET /v3/organizations::as admin")
+			AddReportEntry(experiment.Name, experiment)
+
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+				experiment.Sample(func(idx int) {
+					experiment.MeasureDuration("GET /v3/organizations", func() {
+						helpers.TimeCFCurl(testConfig.LongTimeout, "/v3/organizations")
+					})
+				}, gmeasure.SamplingConfig{N: testConfig.Samples})
+			})
+		})
+
+		It("as regular user", func() {
+			experiment := gmeasure.NewExperiment("GET /v3/organizations::as regular user")
+			AddReportEntry(experiment.Name, experiment)
+
+			workflowhelpers.AsUser(testSetup.RegularUserContext(), testConfig.LongTimeout, func() {
+				experiment.Sample(func(idx int) {
+					experiment.MeasureDuration("GET /v3/organizations", func() {
+						helpers.TimeCFCurl(testConfig.LongTimeout, "/v3/organizations")
+					})
+				}, gmeasure.SamplingConfig{N: testConfig.Samples})
+			})
+		})
+
+		It(fmt.Sprintf("as regular user with page size %d", testConfig.LargePageSize), func() {
+			experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/organizations::as regular user with page size %d", testConfig.LargePageSize))
+			AddReportEntry(experiment.Name, experiment)
+
+			workflowhelpers.AsUser(testSetup.RegularUserContext(), testConfig.LongTimeout, func() {
+				experiment.Sample(func(idx int) {
+					experiment.MeasureDuration("GET /v3/organizations", func() {
+						helpers.TimeCFCurl(testConfig.LongTimeout, fmt.Sprintf("/v3/organizations?per_page=%d", testConfig.LargePageSize))
+					})
+				}, gmeasure.SamplingConfig{N: testConfig.Samples})
+			})
+		})
+	})
+})

--- a/scripts/mysql/assign_user_disjoint_org_roles.tmpl.sql
+++ b/scripts/mysql/assign_user_disjoint_org_roles.tmpl.sql
@@ -1,0 +1,27 @@
+CREATE PROCEDURE assign_user_disjoint_org_roles(
+    IN user_guid VARCHAR(255)
+)
+BEGIN
+    DECLARE v_user_id INT;
+    SELECT id FROM users WHERE guid = user_guid INTO v_user_id;
+
+    INSERT INTO organizations_managers (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, ROW_NUMBER() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 0;
+
+    INSERT INTO organizations_billing_managers (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, ROW_NUMBER() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 1;
+
+    INSERT INTO organizations_auditors (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, ROW_NUMBER() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 2;
+
+    INSERT INTO organizations_users (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, ROW_NUMBER() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 3;
+END;

--- a/scripts/pgsql_functions.tmpl.sql
+++ b/scripts/pgsql_functions.tmpl.sql
@@ -706,3 +706,40 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;
+
+-- ============================================================= --
+
+-- FUNC DEF:
+-- Each of the 4 org-role tables receives an equal, non-overlapping slice, so the
+-- union of readable orgs equals exactly the full selected_orgs count on every run
+-- (deterministic), while still exercising all 4 role tables in the visibility union.
+CREATE OR REPLACE FUNCTION assign_user_disjoint_org_roles(
+    user_guid TEXT
+) RETURNS void AS
+$$
+DECLARE
+    v_user_id int;
+BEGIN
+    SELECT id FROM users WHERE guid = user_guid INTO v_user_id;
+
+    INSERT INTO organizations_managers (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, row_number() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 0;
+
+    INSERT INTO organizations_billing_managers (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, row_number() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 1;
+
+    INSERT INTO organizations_auditors (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, row_number() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 2;
+
+    INSERT INTO organizations_users (organization_id, user_id)
+    SELECT id, v_user_id FROM (
+        SELECT id, row_number() OVER (ORDER BY id) - 1 AS rn FROM selected_orgs
+    ) s WHERE s.rn % 4 = 3;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Tests GET /v3/organizations as admin, regular user, and regular user with page size 500 against 100k orgs.

Seeding uses assign_user_disjoint_org_roles to assign all 4 org roles across disjoint quarters of a fixed-size selected_orgs table (orgs/10 = 10k orgs), making the visible-org count deterministic across runs.