### PR TITLE
Add organization quotas perf suite

### DIFF
--- a/organization_quotas/v1/organization_quotas_suite_test.go
+++ b/organization_quotas/v1/organization_quotas_suite_test.go
@@ -1,0 +1,79 @@
+package organization_quotas
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+)
+
+var testConfig = helpers.NewConfig()
+var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
+var ccdb *sql.DB
+var uaadb *sql.DB
+var ctx context.Context
+
+const test_version = "v1"
+
+const (
+	// main test parameters:
+	orgs      = 100000
+	orgQuotas = 50 // results in 100000 / 50 = 2000 orgs per quota
+)
+
+var _ = BeforeSuite(func() {
+	testSetup = workflowhelpers.NewTestSuiteSetup(&testConfig)
+	testSetup.Setup()
+	ccdb, uaadb, ctx = helpers.OpenDbConnections(testConfig)
+	helpers.ImportStoredProcedures(ccdb, ctx, testConfig)
+
+	createOrgStatement := fmt.Sprintf("create_orgs(%d)", orgs)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createOrgStatement, testConfig)
+
+	createQuotasStatement := fmt.Sprintf("create_org_quotas_and_distribute_orgs(%d)", orgQuotas)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, createQuotasStatement, testConfig)
+
+	orgsAssignedToRegularUser := orgs / 10
+	selectOrgsRandomlyStatement := fmt.Sprintf("create_selected_orgs_table(%d)", orgsAssignedToRegularUser)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, selectOrgsRandomlyStatement, testConfig)
+
+	regularUserGUID := helpers.GetUserGUID(testSetup.RegularUserContext(), testConfig)
+	assignDisjointOrgRoles := fmt.Sprintf("assign_user_disjoint_org_roles('%s')", regularUserGUID)
+	helpers.ExecuteStoredProcedure(ccdb, ctx, assignDisjointOrgRoles, testConfig)
+
+	helpers.AnalyzeDB(ccdb, ctx, testConfig)
+})
+
+var _ = AfterSuite(func() {
+	helpers.CleanupTestData(ccdb, uaadb, ctx, testConfig)
+
+	err := ccdb.Close()
+	if err != nil {
+		log.Print(err)
+	}
+
+	if uaadb != nil {
+		err = uaadb.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}
+})
+
+var _ = ReportAfterSuite("Organization quotas test suite", func(report types.Report) {
+	helpers.GenerateReports(helpers.ConfigureJsonReporter(&testConfig, "organization_quotas", "organization_quotas", test_version), report)
+})
+
+func TestOrganizationQuotas(t *testing.T) {
+	helpers.LoadConfig(&testConfig)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OrganizationQuotasTest Suite")
+}

--- a/organization_quotas/v1/organization_quotas_test.go
+++ b/organization_quotas/v1/organization_quotas_test.go
@@ -1,0 +1,54 @@
+package organization_quotas
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry/cf-performance-tests/helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega/gmeasure"
+)
+
+var _ = Describe("organization_quotas", func() {
+	Describe("GET /v3/organization_quotas", func() {
+
+		It("as admin", func() {
+			experiment := gmeasure.NewExperiment("GET /v3/organization_quotas::as admin")
+			AddReportEntry(experiment.Name, experiment)
+
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testConfig.LongTimeout, func() {
+				experiment.Sample(func(idx int) {
+					experiment.MeasureDuration("GET /v3/organization_quotas", func() {
+						helpers.TimeCFCurl(testConfig.LongTimeout, "/v3/organization_quotas")
+					})
+				}, gmeasure.SamplingConfig{N: testConfig.Samples})
+			})
+		})
+
+		It("as regular user", func() {
+			experiment := gmeasure.NewExperiment("GET /v3/organization_quotas::as regular user")
+			AddReportEntry(experiment.Name, experiment)
+
+			workflowhelpers.AsUser(testSetup.RegularUserContext(), testConfig.LongTimeout, func() {
+				experiment.Sample(func(idx int) {
+					experiment.MeasureDuration("GET /v3/organization_quotas", func() {
+						helpers.TimeCFCurl(testConfig.LongTimeout, "/v3/organization_quotas")
+					})
+				}, gmeasure.SamplingConfig{N: testConfig.Samples})
+			})
+		})
+
+		It(fmt.Sprintf("as regular user with page size %d", testConfig.LargePageSize), func() {
+			experiment := gmeasure.NewExperiment(fmt.Sprintf("GET /v3/organization_quotas::as regular user with page size %d", testConfig.LargePageSize))
+			AddReportEntry(experiment.Name, experiment)
+
+			workflowhelpers.AsUser(testSetup.RegularUserContext(), testConfig.LongTimeout, func() {
+				experiment.Sample(func(idx int) {
+					experiment.MeasureDuration("GET /v3/organization_quotas", func() {
+						helpers.TimeCFCurl(testConfig.LongTimeout, fmt.Sprintf("/v3/organization_quotas?per_page=%d", testConfig.LargePageSize))
+					})
+				}, gmeasure.SamplingConfig{N: testConfig.Samples})
+			})
+		})
+	})
+})

--- a/scripts/mysql/create_org_quotas_and_distribute_orgs.tmpl.sql
+++ b/scripts/mysql/create_org_quotas_and_distribute_orgs.tmpl.sql
@@ -1,0 +1,31 @@
+CREATE PROCEDURE create_org_quotas_and_distribute_orgs(
+    num_quotas INT
+)
+BEGIN
+    DECLARE quota_name_prefix VARCHAR(255) DEFAULT '{{.Prefix}}-org-quota-';
+    DECLARE org_name_query VARCHAR(255) DEFAULT '{{.Prefix}}-org-%';
+    DECLARE i INT DEFAULT 0;
+
+    -- create the quotas
+    WHILE i < num_quotas DO
+        INSERT INTO quota_definitions
+            (guid, name, non_basic_services_allowed, total_services, memory_limit, total_routes)
+        VALUES
+            (uuid(), CONCAT(quota_name_prefix, uuid()), true, -1, -1, -1);
+        SET i = i + 1;
+    END WHILE;
+
+    -- distribute prefixed orgs across the new quotas round-robin
+    UPDATE organizations o
+    JOIN (
+        SELECT id, (ROW_NUMBER() OVER (ORDER BY id) - 1) % num_quotas AS quota_idx
+        FROM organizations
+        WHERE name LIKE org_name_query
+    ) sub ON o.id = sub.id
+    JOIN (
+        SELECT id, ROW_NUMBER() OVER (ORDER BY id) - 1 AS rn
+        FROM quota_definitions
+        WHERE name LIKE CONCAT(quota_name_prefix, '%')
+    ) q ON sub.quota_idx = q.rn
+    SET o.quota_definition_id = q.id;
+END;

--- a/scripts/pgsql_functions.tmpl.sql
+++ b/scripts/pgsql_functions.tmpl.sql
@@ -710,6 +710,43 @@ $$ LANGUAGE plpgsql;
 -- ============================================================= --
 
 -- FUNC DEF:
+CREATE OR REPLACE FUNCTION create_org_quotas_and_distribute_orgs(
+    num_quotas INTEGER
+) RETURNS void AS
+$$
+DECLARE
+    quota_name_prefix text := '{{.Prefix}}-org-quota-';
+    org_name_query text := '{{.Prefix}}-org-%';
+    quota_ids int[];
+BEGIN
+    -- create the quotas
+    FOR _ IN 1..num_quotas LOOP
+        INSERT INTO quota_definitions
+            (guid, name, non_basic_services_allowed, total_services, memory_limit, total_routes)
+        VALUES
+            (gen_random_uuid(), quota_name_prefix || gen_random_uuid(), true, -1, -1, -1);
+    END LOOP;
+
+    -- collect the ids of the quotas we just created
+    SELECT array_agg(id ORDER BY id) INTO quota_ids
+    FROM quota_definitions WHERE name LIKE quota_name_prefix || '%';
+
+    -- distribute prefixed orgs across the new quotas round-robin
+    UPDATE organizations o
+    SET quota_definition_id = quota_ids[1 + (sub.rn % num_quotas)]
+    FROM (
+        SELECT id, row_number() OVER (ORDER BY id) - 1 AS rn
+        FROM organizations
+        WHERE name LIKE org_name_query
+    ) sub
+    WHERE o.id = sub.id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================= --
+
+-- FUNC DEF:
+-- Assigns the user one org role per disjoint quarter of the selected_orgs table.
 -- Each of the 4 org-role tables receives an equal, non-overlapping slice, so the
 -- union of readable orgs equals exactly the full selected_orgs count on every run
 -- (deterministic), while still exercising all 4 role tables in the visibility union.


### PR DESCRIPTION
Tests GET /v3/organization_quotas as admin, regular user, and regular user
with page size 500 against 100k orgs distributed across 50 quotas (2000 orgs
per quota).

Adds create_org_quotas_and_distribute_orgs stored procedure to create N quotas
and assign orgs round-robin. Reuses assign_user_disjoint_org_roles (from the
organizations suite) to keep the visible-org count deterministic across runs.